### PR TITLE
Remove `timeout` from calls to `KafkaProducer.Close()`

### DIFF
--- a/syslog/syslog_producer.go
+++ b/syslog/syslog_producer.go
@@ -110,7 +110,7 @@ func (this *SyslogProducer) Stop() {
 	close(this.incoming)
 
 	for _, producer := range this.producers {
-		producer.Close(time.Second)
+		producer.Close()
 	}
 }
 


### PR DESCRIPTION
`KafkaProducer.Close()` does not take a `timeout` parameter any more after this change: https://github.com/elodina/siesta-producer/commit/94fa7677332126e9eaca87ebc95727e6b3ed52b6#diff-89055728bcbdc632fedfa979e7420a06L284